### PR TITLE
Made package "go get"-able

### DIFF
--- a/arc/arc.go
+++ b/arc/arc.go
@@ -1,6 +1,6 @@
 package arc
 
-import "go-cache/base"
+import "github.com/moovweb/go-cache/base"
 
 func NewARCache(size int) *base.BaseCache {
 	arc := newCdbm()

--- a/arc/arc_test.go
+++ b/arc/arc_test.go
@@ -1,7 +1,7 @@
 package arc
 
 import "testing"
-import "go-cache"
+import "github.com/moovweb/go-cache"
 import "math/rand"
 import "time"
 import "strconv"
@@ -20,17 +20,17 @@ func TestGet(t *testing.T) {
 	countCleaned := 0
 	countAccess := 10000
 
-	c := NewARCache(cacheSize*5)
+	c := NewARCache(cacheSize * 5)
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
 	rand.Seed(time.Now().Unix())
 
-	for i := 0; i < countAccess; i ++ {
-		j := rand.Intn(cacheSize*2)
-		key := "key"+strconv.Itoa(j)
+	for i := 0; i < countAccess; i++ {
+		j := rand.Intn(cacheSize * 2)
+		key := "key" + strconv.Itoa(j)
 		val, err := c.Get(key)
 
 		if err == cache.CacheMiss {
@@ -42,11 +42,11 @@ func TestGet(t *testing.T) {
 	}
 
 	c.Check()
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, c.GetUsage())
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}

--- a/arc/cdb.go
+++ b/arc/cdb.go
@@ -4,8 +4,8 @@ import (
 	"container/list"
 	"errors"
 
-	. "go-cache"
-	"go-cache/base"
+	. "github.com/moovweb/go-cache"
+	"github.com/moovweb/go-cache/base"
 )
 
 const (

--- a/arc/list.go
+++ b/arc/list.go
@@ -1,21 +1,20 @@
 package arc
 
 import "container/list"
+
 //import . "go-cache"
-import "go-cache/base"
+import "github.com/moovweb/go-cache/base"
 
 type CdbList struct {
-	l *list.List
+	l    *list.List
 	size int
 }
-
 
 func (cl *CdbList) PushBack(cdb base.CacheDirectoryBlock) *list.Element {
 	e := cl.l.PushBack(cdb)
 	cl.size += cdb.(*ArcCdb).size
 	return e
 }
-
 
 func (cl *CdbList) Remove(e *list.Element) base.CacheDirectoryBlock {
 	cdb := cl.l.Remove(e).(base.CacheDirectoryBlock)

--- a/base/base.go
+++ b/base/base.go
@@ -1,6 +1,6 @@
 package base
 
-import . "go-cache"
+import . "github.com/moovweb/go-cache"
 import "sync"
 
 type BaseCache struct {

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -1,7 +1,7 @@
 package base
 
 import "testing"
-import "go-cache"
+import "github.com/moovweb/go-cache"
 import "math/rand"
 import "time"
 import "strconv"
@@ -25,15 +25,15 @@ func TestGet(t *testing.T) {
 
 	c := NewSafeBaseCache(cacheSize*5, cdbm)
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
 	rand.Seed(time.Now().Unix())
 
-	for i := 0; i < countAccess; i ++ {
-		j := rand.Intn(cacheSize*2)
-		key := "key"+strconv.Itoa(j)
+	for i := 0; i < countAccess; i++ {
+		j := rand.Intn(cacheSize * 2)
+		key := "key" + strconv.Itoa(j)
 		val, err := c.Get(key)
 
 		if err == cache.CacheMiss {
@@ -46,11 +46,11 @@ func TestGet(t *testing.T) {
 	}
 
 	c.Check()
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, cacheSize)
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}

--- a/base/cdb.go
+++ b/base/cdb.go
@@ -1,6 +1,6 @@
 package base
 
-import . "go-cache"
+import . "github.com/moovweb/go-cache"
 
 type CacheDirectoryBlock interface {
 	GetKey() string
@@ -11,7 +11,7 @@ type CacheDirectoryBlock interface {
 
 type BaseCdb struct {
 	object CacheObject
-	key string
+	key    string
 }
 
 func (cdb *BaseCdb) GetKey() string {

--- a/base/cdbm.go
+++ b/base/cdbm.go
@@ -1,6 +1,6 @@
 package base
 
-import . "go-cache"
+import . "github.com/moovweb/go-cache"
 import "math/rand"
 
 type CdbManager interface {
@@ -38,7 +38,7 @@ func (cdbm *BasicCdbm) MakeSpace(objectSize, sizeLimit int, f CacheCleanFunc) (C
 		return nil, ObjectTooBig
 	}
 
-	//there is nothing 
+	//there is nothing
 	if len(cdbm.Hash) == 0 {
 		return nil, nil
 	}

--- a/lru/cdb.go
+++ b/lru/cdb.go
@@ -2,8 +2,8 @@ package lru
 
 import (
 	"container/list"
-	. "go-cache"
-	"go-cache/base"
+	. "github.com/moovweb/go-cache"
+	"github.com/moovweb/go-cache/base"
 )
 
 type LruCdbm struct {
@@ -54,14 +54,14 @@ func (cdbm *LruCdbm) MakeSpace(objectSize, sizeLimit int, f CacheCleanFunc) (bas
 	if sizeLimit < objectSize {
 		return nil, ObjectTooBig
 	}
-	
-	//there is nothing 
+
+	//there is nothing
 	if len(cdbm.Hash) == 0 {
 		return nil, nil
 	}
 
 	var repl base.CacheDirectoryBlock
-	
+
 	for avail := sizeLimit - cdbm.Size; objectSize > avail; avail = sizeLimit - cdbm.Size {
 		lru := cdbm.cdbs.Front()
 		if lru == nil {
@@ -85,7 +85,7 @@ func (cdbm *LruCdbm) Replace(key string, object CacheObject, sizeLimit int, f Ca
 	if err != nil {
 		return err
 	}
-	
+
 	if cdb == nil {
 		cdb = newCacheDirectorBlock()
 	}

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -1,6 +1,6 @@
 package lru
 
-import "go-cache/base"
+import "github.com/moovweb/go-cache/base"
 
 func NewLRUCache(size int) *base.BaseCache {
 	lru := newCdbm()

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -1,11 +1,10 @@
 package lru
 
 import "testing"
-import "go-cache"
+import "github.com/moovweb/go-cache"
 import "math/rand"
 import "time"
 import "strconv"
-
 
 type StringObject struct {
 	s string
@@ -22,17 +21,17 @@ func TestGet(t *testing.T) {
 	countAccess := 1000
 	countMiss := 0
 
-	c := NewLRUCache(cacheSize*5)
+	c := NewLRUCache(cacheSize * 5)
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
 	rand.Seed(time.Now().Unix())
 
-	for i := 0; i < countAccess; i ++ {
-		j := rand.Intn(cacheSize*2)
-		key := "key"+strconv.Itoa(j)
+	for i := 0; i < countAccess; i++ {
+		j := rand.Intn(cacheSize * 2)
+		key := "key" + strconv.Itoa(j)
 		val, err := c.Get(key)
 
 		if err == cache.CacheMiss {
@@ -45,11 +44,11 @@ func TestGet(t *testing.T) {
 	}
 
 	c.Check()
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, cacheSize)
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}

--- a/test/fetch_test.go
+++ b/test/fetch_test.go
@@ -1,12 +1,13 @@
 package test
 
 import "testing"
-import "go-cache/arc"
-import "go-cache/lru"
-import "go-cache/base"
+import "github.com/moovweb/go-cache/arc"
+import "github.com/moovweb/go-cache/lru"
+import "github.com/moovweb/go-cache/base"
 import "strings"
 import "io/ioutil"
 import "sync"
+
 //import "time"
 
 func TestArcFetch(t *testing.T) {
@@ -24,10 +25,10 @@ func TestArcFetch(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				_, err := c.Get(lines[i])
 				if err != nil {
-					c.Set(lines[i], &StringObject{s:lines[i]})
+					c.Set(lines[i], &StringObject{s: lines[i]})
 				}
 			}
 			wg.Done()
@@ -37,7 +38,7 @@ func TestArcFetch(t *testing.T) {
 
 	c.Check()
 
-	for key, obj := range(c.Collect()) {
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}
@@ -58,10 +59,10 @@ func TestLRUFetch(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				_, err := c.Get(lines[i])
 				if err != nil {
-					c.Set(lines[i], &StringObject{s:lines[i]})
+					c.Set(lines[i], &StringObject{s: lines[i]})
 				}
 			}
 			wg.Done()
@@ -71,7 +72,7 @@ func TestLRUFetch(t *testing.T) {
 
 	c.Check()
 
-	for key, obj := range(c.Collect()) {
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}
@@ -93,10 +94,10 @@ func TestRandomFetch(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				_, err := c.Get(lines[i])
 				if err != nil {
-					c.Set(lines[i], &StringObject{s:lines[i]})
+					c.Set(lines[i], &StringObject{s: lines[i]})
 				}
 			}
 			wg.Done()
@@ -106,7 +107,7 @@ func TestRandomFetch(t *testing.T) {
 
 	c.Check()
 
-	for key, obj := range(c.Collect()) {
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}

--- a/test/real_test.go
+++ b/test/real_test.go
@@ -1,10 +1,10 @@
 package test
 
 import "testing"
-import "go-cache"
-import "go-cache/arc"
-import "go-cache/lru"
-import "go-cache/base"
+import "github.com/moovweb/go-cache"
+import "github.com/moovweb/go-cache/arc"
+import "github.com/moovweb/go-cache/lru"
+import "github.com/moovweb/go-cache/base"
 import "strings"
 import "io/ioutil"
 import "sync"
@@ -20,7 +20,6 @@ func (o *StringObject) Size() int {
 const cacheSize = 20 * 40
 const concurrency = 20
 
-
 func TestARC(t *testing.T) {
 	countCleaned := 0
 	countAdded := 0
@@ -34,7 +33,7 @@ func TestARC(t *testing.T) {
 	str := string(data)
 	lines := strings.Split(str, "\n")
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
@@ -44,7 +43,7 @@ func TestARC(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				val, err := c.Get(lines[i])
 				if err == cache.CacheMiss {
 					countAdded += len(lines[i])
@@ -61,11 +60,11 @@ func TestARC(t *testing.T) {
 
 	c.Check()
 
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, c.GetUsage())
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}
@@ -86,7 +85,7 @@ func TestLRU(t *testing.T) {
 	str := string(data)
 	lines := strings.Split(str, "\n")
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
@@ -96,7 +95,7 @@ func TestLRU(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				val, err := c.Get(lines[i])
 				if err == cache.CacheMiss {
 					countAdded += len(lines[i])
@@ -113,11 +112,11 @@ func TestLRU(t *testing.T) {
 
 	c.Check()
 
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, c.GetUsage())
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}
@@ -138,7 +137,7 @@ func TestRandom(t *testing.T) {
 	str := string(data)
 	lines := strings.Split(str, "\n")
 
-	c.SetCleanFunc(func (obj cache.CacheObject) error {
+	c.SetCleanFunc(func(obj cache.CacheObject) error {
 		countCleaned += obj.Size()
 		return nil
 	})
@@ -148,7 +147,7 @@ func TestRandom(t *testing.T) {
 	for j := 0; j < concurrency; j++ {
 		wg.Add(1)
 		go func() {
-			for i := 0; i < countAccess; i ++ {
+			for i := 0; i < countAccess; i++ {
 				val, err := c.Get(lines[i])
 				if err == cache.CacheMiss {
 					countAdded += len(lines[i])
@@ -165,11 +164,11 @@ func TestRandom(t *testing.T) {
 
 	c.Check()
 
-	if countCleaned + c.GetUsage() != countAdded {
+	if countCleaned+c.GetUsage() != countAdded {
 		t.Errorf("numbers of data items dont match: %d != %d + %d\n", countAdded, countCleaned, c.GetUsage())
 	}
-	
-	for key, obj := range(c.Collect()) {
+
+	for key, obj := range c.Collect() {
 		if key != obj.(*StringObject).s {
 			t.Errorf("key does not match the cached value")
 		}


### PR DESCRIPTION
While you can "go get github.com/moovweb/go-cache", trying to build any of the subpackes will fail because they reference "go-cache", not "github.com/moovweb/go-cache" and causes a compile-time error. This pull request adds the full source location to the subpackages. (Other changes are due to gofmt)
